### PR TITLE
Added missing line in reading-writing of excercise express routing

### DIFF
--- a/nodejs-http/exercise-express-routing/reading-writing/app.js
+++ b/nodejs-http/exercise-express-routing/reading-writing/app.js
@@ -23,5 +23,5 @@ app.get('/products', (req, res) => {
   // implement
 })
 
-app.listen(port, console.log(`Listening on port: ${port}`))
+app.listen(port, () => console.log(`Example app listening on port ${port}!`))
   ```

--- a/nodejs-http/exercise-express-routing/reading-writing/app.js
+++ b/nodejs-http/exercise-express-routing/reading-writing/app.js
@@ -22,4 +22,6 @@ app.delete('/products/:id', function (req, res) {
 app.get('/products', (req, res) => {
   // implement
 })
+
+app.listen(port, console.log(`Listening on port: ${port}`))
   ```


### PR DESCRIPTION
Code was missing for the code in **Unit 5** **part 3** of the _Build a web API with Node.js and Express_ section.  

To handle requests, the **app.js** file missed the line `app.listen(...)`.  You can test that when you run **node app.js**  in a terminal and then opened another one to run any of the client's files, the server throws an error because wasn´t able to find the endpoint. 

There is not any statement on the exercise that specified that the student had to add that missing line of code, even though, it said that you have to fill all the code for the routings.

