### PR TITLE
fixing line 25

### DIFF
--- a/nodejs-http/exercise-express-routing/parameters/app.js
+++ b/nodejs-http/exercise-express-routing/parameters/app.js
@@ -22,9 +22,7 @@ const products = [
 
 app.get("/", (req, res) => res.send("Hello API!"));
 
-app.get("/products/:id", (req, res) => {
-  res.json(products.find((p) => p.id === +req.params.id));
-});
+app.get("/products/:id", (req, res) => {});
 
 app.get("/products", (req, res) => {});
 


### PR DESCRIPTION
Fixing line 25 to make the code correspond with https://learn.microsoft.com/en-us/training/modules/node-web-routes/3-exercise-route-query-parameters. Before the change, line 25 was the replaced code, not the original code.