### PR TITLE
chore: include code samples for unit 3 from Node.js Intro Course

### DIFF
--- a/nodejs-intro/3-how-nodejs-works/async-await.js
+++ b/nodejs-intro/3-how-nodejs-works/async-await.js
@@ -1,0 +1,17 @@
+// async/await asynchronous example
+
+const fs = require('fs').promises;
+const filePath = './file.txt';
+
+async function readFileAsync() {
+    try {
+        // request to read a file
+        const data = await fs.readFile(filePath, 'utf8');
+        console.log(data);
+        console.log('Done!');
+    } catch (error) {
+        console.log('An error occurred...: ', error);
+    }
+}
+
+readFileAsync();

--- a/nodejs-intro/3-how-nodejs-works/callbacks.js
+++ b/nodejs-intro/3-how-nodejs-works/callbacks.js
@@ -1,0 +1,14 @@
+// callback asynchrounous example
+
+const fs = require('fs');
+const filePath = './file.txt';
+
+// request to read a file
+fs.readFile(filePath, 'utf8', (error, data) => {
+    if (error) {
+        console.log('An error occurred...: ', error);
+    } else {
+        console.log(data);
+        console.log('Done!');
+    }
+});

--- a/nodejs-intro/3-how-nodejs-works/file.txt
+++ b/nodejs-intro/3-how-nodejs-works/file.txt
@@ -1,0 +1,1 @@
+Hi, developers!

--- a/nodejs-intro/3-how-nodejs-works/promises.js
+++ b/nodejs-intro/3-how-nodejs-works/promises.js
@@ -1,0 +1,14 @@
+// promises asynchronous example
+
+const fs = require('fs').promises;
+const filePath = './file.txt';
+
+// request to read a file
+fs.readFile(filePath, 'utf8')
+    .then((data) => {
+        console.log(data);
+        console.log('Done!');
+    })
+    .catch((error) => {
+        console.log('An error occurred...: ', error);
+    });

--- a/nodejs-intro/3-how-nodejs-works/synchronous-api.js
+++ b/nodejs-intro/3-how-nodejs-works/synchronous-api.js
@@ -1,0 +1,13 @@
+// synchronous example
+
+const fs = require('fs');
+const filePath = './file.txt';
+
+try {
+    // request to read a file
+    const data = fs.readFileSync(filePath, 'utf8');
+    console.log(data);
+    console.log('Done!');
+} catch (error) {
+    console.log('An error occurred...: ', error);
+}


### PR DESCRIPTION
Proposing a different code samples for **[Unit 03 from the Introduction to Node.Js Course](https://learn.microsoft.com/en-us/training/modules/intro-to-nodejs/3-how-works?pivots=windows)**

Code samples related to

* **Callbacks**
* **Promises**
* **Async/await**
* **Synchronous APIs**

### Why the change?

The way it's currently structured the code sample, the '_users/developers_' can't effectively simulate a file reading in this part of the unit, which might lead to them overlooking the training continuity. Examples where developers can test and see code execution stimulate training continuity.

### How to run the sample?

Right-click on the `3-how-nodejs-works` folder, select `Open in integrated terminal` and then run the command: `node <file-name>`

![nodejs-intro-05](https://github.com/MicrosoftDocs/node-essentials/assets/1631477/d9c3edfa-ed64-43e3-a7b3-c29de1a8ddfd)
