### PR TITLE
Create a version using Playwright [Exercice 05 - Install Dependencies]

### DIFF
--- a/node-dependencies/5-exercise-dependency-playwright/__tests__/address-parser.spec.js
+++ b/node-dependencies/5-exercise-dependency-playwright/__tests__/address-parser.spec.js
@@ -1,8 +1,8 @@
 const { test, expect } = require('@playwright/test');
-const { parse } = require('../address-parser');
+const { addressParser } = require('../address-parser');
 
 test('Address Parser', () => {
-    const result = parse(
+    const result = addressParser(
         'order: 3 books to address: 112 street city here is my payment info: cardnumber'
     );
 

--- a/node-dependencies/5-exercise-dependency-playwright/__tests__/address-parser.spec.js
+++ b/node-dependencies/5-exercise-dependency-playwright/__tests__/address-parser.spec.js
@@ -1,0 +1,14 @@
+const { test, expect } = require('@playwright/test');
+const { parse } = require('../address-parser');
+
+test('Address Parser', () => {
+    const result = parse(
+        'order: 3 books to address: 112 street city here is my payment info: cardnumber'
+    );
+
+    expect(result).toEqual({
+        order: '3 books',
+        address: '112 street city',
+        payment: 'cardnumber',
+    });
+});

--- a/node-dependencies/5-exercise-dependency-playwright/address-parser.js
+++ b/node-dependencies/5-exercise-dependency-playwright/address-parser.js
@@ -1,0 +1,4 @@
+exports.parse = function parseOrder(order) {
+    const match = order.match(/order:\s(?<order>\w+\s\w+).*address:\s(?<address>\w+\s\w+\s\w+).*payment info:\s(?<payment>\w+)/)
+    return match.groups;
+  }

--- a/node-dependencies/5-exercise-dependency-playwright/address-parser.js
+++ b/node-dependencies/5-exercise-dependency-playwright/address-parser.js
@@ -1,4 +1,4 @@
-exports.parse = function parseOrder(order) {
+exports.addressParser = function parseOrder(order) {
     const match = order.match(/order:\s(?<order>\w+\s\w+).*address:\s(?<address>\w+\s\w+\s\w+).*payment info:\s(?<payment>\w+)/)
     return match.groups;
   }

--- a/node-dependencies/5-exercise-dependency-playwright/package-lock.json
+++ b/node-dependencies/5-exercise-dependency-playwright/package-lock.json
@@ -1,0 +1,71 @@
+{
+  "name": "5-exercise-dependency-playwright",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "5-exercise-dependency-playwright",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@playwright/test": "^1.40.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.40.0.tgz",
+      "integrity": "sha512-PdW+kn4eV99iP5gxWNSDQCbhMaDVej+RXL5xr6t04nbKLCBwYtA046t7ofoczHOm8u6c+45hpDKQVZqtqwkeQg==",
+      "dependencies": {
+        "playwright": "1.40.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.40.0.tgz",
+      "integrity": "sha512-gyHAgQjiDf1m34Xpwzaqb76KgfzYrhK7iih+2IzcOCoZWr/8ZqmdBw+t0RU85ZmfJMgtgAiNtBQ/KS2325INXw==",
+      "dependencies": {
+        "playwright-core": "1.40.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.40.0.tgz",
+      "integrity": "sha512-fvKewVJpGeca8t0ipM56jkVSU6Eo0RmFvQ/MaCQNDYm+sdvKkMBBWTE1FdeMqIdumRaXXjZChWHvIzCGM/tA/Q==",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    }
+  }
+}

--- a/node-dependencies/5-exercise-dependency-playwright/package.json
+++ b/node-dependencies/5-exercise-dependency-playwright/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "5-exercise-dependency-playwright",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@playwright/test": "^1.40.0"
+  }
+}

--- a/node-dependencies/5-exercise-dependency-playwright/package.json
+++ b/node-dependencies/5-exercise-dependency-playwright/package.json
@@ -8,7 +8,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "@playwright/test": "^1.40.0"
   }


### PR DESCRIPTION
Once [Playwright](https://playwright.dev/) is an Open-Source tool and is from Microsoft, I think we could change the example using Playwright! I created this branch and ask you to consider the possibility. It could be a way to promote the tool throughout the Node.js course.

Link: [Exercise - Install packages](https://learn.microsoft.com/en-us/training/modules/create-nodejs-project-dependencies/5-exercise-dependency)

![image](https://github.com/MicrosoftDocs/node-essentials/assets/1631477/bbce8ba1-06f9-422c-92d3-7138a8045093)
